### PR TITLE
LEV-321 Copy artifacts from secondary container

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -29,9 +29,8 @@ main() {
 copy_artifacts() {
   local pod_name = $1
   local container_name = $2
-  local artifact_paths = $3
 
-  (kubectl exec "$pod_name" -c $container_name -- /bin/bash -c 'tar czf - $(shopt -s nullglob; IFS=";" list=($artifact_paths); echo -n "${list[@]}") || true' | tar xzf - -C $(pwd) || true) &> /dev/null
+  (kubectl exec "$pod_name" -c $container_name -- /bin/bash -c 'tar czf - $(shopt -s nullglob; IFS=";" list=($BUILDKITE_ARTIFACT_PATHS); echo -n "${list[@]}") || true' | tar xzf - -C $(pwd) || true) &> /dev/null
 }
 
 cleanup() {
@@ -40,12 +39,12 @@ cleanup() {
 
   if [[ -n "$BUILDKITE_ARTIFACT_PATHS" ]]; then
     echo "--- :kubernetes: Copying artifacts..."
-    copy_artifacts $pod_name "run" $BUILDKITE_ARTIFACT_PATHS
+    copy_artifacts $pod_name "run"
   fi
 
   if [[ -n "$SECONDARY_ARTIFACT_PATHS" ]]; then
     echo "--- :kubernetes: Copying secondary artifacts..."
-    copy_artifacts $pod_name $SECONDARY_CONTAINER_NAME $SECONDARY_ARTIFACT_PATHS
+    copy_artifacts $pod_name $SECONDARY_CONTAINER_NAME
   fi
 
   (kubectl patch pod --patch '{"spec":{"activeDeadlineSeconds":1}}' "$pod_name" &> /dev/null || true)

--- a/hooks/command
+++ b/hooks/command
@@ -42,7 +42,7 @@ cleanup() {
     copy_artifacts $pod_name "run"
   fi
 
-  SECONDARY_CONTAINER_NAME=${$SECONDARY_CONTAINER_NAME:-""}
+  SECONDARY_CONTAINER_NAME=${SECONDARY_CONTAINER_NAME:-}
   if [[ -n "$SECONDARY_CONTAINER_NAME" ]]; then
     echo "--- :kubernetes: Copying secondary artifacts..."
     copy_artifacts $pod_name $SECONDARY_CONTAINER_NAME

--- a/hooks/command
+++ b/hooks/command
@@ -26,13 +26,26 @@ main() {
   kubectl exec -c run "$pod_name" -- $BUILDKITE_COMMAND
 }
 
+copy_artifacts() {
+  local pod_name = $1
+  local container_name = $2
+  local artifact_paths = $3
+
+  (kubectl exec "$pod_name" -c $container_name -- /bin/bash -c 'tar czf - $(shopt -s nullglob; IFS=";" list=($artifact_paths); echo -n "${list[@]}") || true' | tar xzf - -C $(pwd) || true) &> /dev/null
+}
+
 cleanup() {
   local pod_name
   pod_name="$BUILDKITE_PIPELINE_SLUG-$BUILDKITE_JOB_ID"
 
   if [[ -n "$BUILDKITE_ARTIFACT_PATHS" ]]; then
     echo "--- :kubernetes: Copying artifacts..."
-    (kubectl exec "$pod_name" -c run -- /bin/bash -c 'tar czf - $(shopt -s nullglob; IFS=";" list=($BUILDKITE_ARTIFACT_PATHS); echo -n "${list[@]}") || true' | tar xzf - -C $(pwd) || true) &> /dev/null
+    copy_artifacts $pod_name "run" $BUILDKITE_ARTIFACT_PATHS
+  fi
+
+  if [[ -n "$SECONDARY_ARTIFACT_PATHS" ]]; then
+    echo "--- :kubernetes: Copying secondary artifacts..."
+    copy_artifacts $pod_name $SECONDARY_CONTAINER_NAME $SECONDARY_ARTIFACT_PATHS
   fi
 
   (kubectl patch pod --patch '{"spec":{"activeDeadlineSeconds":1}}' "$pod_name" &> /dev/null || true)

--- a/hooks/command
+++ b/hooks/command
@@ -42,7 +42,8 @@ cleanup() {
     copy_artifacts $pod_name "run"
   fi
 
-  if [[ -n "$SECONDARY_ARTIFACT_PATHS" ]]; then
+  SECONDARY_CONTAINER_NAME=${$SECONDARY_CONTAINER_NAME:-""}
+  if [[ -n "$SECONDARY_CONTAINER_NAME" ]]; then
     echo "--- :kubernetes: Copying secondary artifacts..."
     copy_artifacts $pod_name $SECONDARY_CONTAINER_NAME
   fi

--- a/hooks/command
+++ b/hooks/command
@@ -27,8 +27,8 @@ main() {
 }
 
 copy_artifacts() {
-  local pod_name = $1
-  local container_name = $2
+  local pod_name=$1
+  local container_name=$2
 
   (kubectl exec "$pod_name" -c $container_name -- /bin/bash -c 'tar czf - $(shopt -s nullglob; IFS=";" list=($BUILDKITE_ARTIFACT_PATHS); echo -n "${list[@]}") || true' | tar xzf - -C $(pwd) || true) &> /dev/null
 }


### PR DESCRIPTION
With the current setup we are only copying artifacts from the main container (run) this not enough for end to end testing as we also need the logs of the frontend container. Otherwise, developers won't have all the information they need when seeing a failing test.

The idea is to have the following env vars:

- `SECONDARY_CONTAINER_NAME`: the name of the container that contains the artifacts to copy
- `SECONDARY_ARTIFACT_PATHS`:  the path of the artifacts to copy

## TODO

Copy each container artifact to different folders to avoid conflicts when both copy the same path/files names.

