### PR TITLE
collect and display information after build

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -26,19 +26,4 @@ main() {
   kubectl exec -c run "$pod_name" -- $BUILDKITE_COMMAND
 }
 
-cleanup() {
-  local pod_name
-  pod_name="$BUILDKITE_PIPELINE_SLUG-$BUILDKITE_JOB_ID"
-
-  if [[ -n "$BUILDKITE_ARTIFACT_PATHS" ]]; then
-    echo "--- :kubernetes: Copying artifacts..."
-    (kubectl exec "$pod_name" -c run -- /bin/bash -c 'tar czf - $(shopt -s nullglob; IFS=";" list=($BUILDKITE_ARTIFACT_PATHS); echo -n "${list[@]}") || true' | tar xzf - -C $(pwd) || true) &> /dev/null
-  fi
-
-  (kubectl patch pod --patch '{"spec":{"activeDeadlineSeconds":1}}' "$pod_name" &> /dev/null || true)
-  (kubectl delete pod "$pod_name" --now=true --wait=false &> /dev/null || true)
-}
-
-trap cleanup EXIT
-
 main "$@"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+main() {
+  local pod_name
+  pod_name="$BUILDKITE_PIPELINE_SLUG-$BUILDKITE_JOB_ID"
+
+  not_ready_containers="$(kubectl get pods $pod_name -o jsonpath='{.status.containerStatuses[?(@.ready == false)].name}')"
+  if [[ -n "$not_ready_containers" ]]; then
+    echo "+++ :kubernetes: :warning: Not all containers were 'ready' when the build finished!"
+    echo "Events:"
+    kubectl get event --field-selector involvedObject.kind=Pod,involvedObject.name=$pod_name || true
+
+    echo -e "\n"
+    echo "Detailed state of 'non-ready' containers:"
+    kubectl get pods $pod_name -o jsonpath='{.status.containerStatuses[?(@.ready == false)]}{.state}{ "\n"}'
+  else
+    echo "--- :kubernetes: All containers were still up when the build finished :v:"
+  fi
+}
+
+main "$@"

--- a/hooks/pre-artifact
+++ b/hooks/pre-artifact
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+main() {
+  local pod_name
+  pod_name="$BUILDKITE_PIPELINE_SLUG-$BUILDKITE_JOB_ID"
+
+  if [[ -n "$BUILDKITE_ARTIFACT_PATHS" ]]; then
+    echo "--- :kubernetes: Copying artifacts..."
+    (kubectl exec "$pod_name" -c run -- /bin/bash -c 'tar czf - $(shopt -s nullglob; IFS=";" list=($BUILDKITE_ARTIFACT_PATHS); echo -n "${list[@]}") || true' | tar xzf - -C $(pwd) || true) &> /dev/null
+  fi
+
+  echo "--- :kubernetes: Retrieving containers logs..."
+  mkdir -p log
+  local container_list
+  container_list=$(kubectl get pods $pod_name -o 'jsonpath={.spec.containers[?(@.name != "run")].name}' || true)
+  for container_name in $container_list
+  do
+    echo "* $container_name"
+    kubectl logs "$pod_name" -c "$container_name" > "log/container-${container_name}.log" || true
+  done
+}
+
+main "$@"

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -3,8 +3,7 @@
 set -euo pipefail
 
 main() {
-  (kubectl patch pod --patch '{"spec":{"activeDeadlineSeconds":1}}' "$BUILDKITE_PIPELINE_SLUG-$BUILDKITE_JOB_ID" &> /dev/null || true)
-  (kubectl delete pod "$BUILDKITE_PIPELINE_SLUG-$BUILDKITE_JOB_ID" --now=true --wait=false &> /dev/null || true)
+  kubectl delete pod "$BUILDKITE_PIPELINE_SLUG-$BUILDKITE_JOB_ID" --now=true --wait=false
 }
 
 main "$@"

--- a/lib/pod.jq
+++ b/lib/pod.jq
@@ -10,7 +10,7 @@ def meld(a; b):
 
 (env | to_entries | map(select(.key | contains("BUILDKITE_")))) + (($ARGS.named.extra_env // {}) | to_entries) | map(.name=.key | del(.key)) as $env |
 
-(env.BUILDKITE_TIMEOUT | tonumber * 60) as $timeout |
+(env.BUILDKITE_TIMEOUT | (tonumber * 60 + 60)) as $timeout |
 
 (
   env.BUILDKITE_PLUGINS // "[]" |


### PR DESCRIPTION
This PR aims at collecting more information when a build finishes, in order to help debugging dependency errors. Since the feedback loop is a bit long, I also tested additional changes with it.

Summary:
* distribute tear down code of *command* into dedicated plugin hooks (*pre-artifact* and *pre-exit*). I encountered some errors when I forced builds to run into timeouts, where the tear commands would be killed. I was about to increase `BUILDKITE_CANCEL_GRACE_PERIOD` but decided to move this code into separate hooks first, and I haven't had problems since.
* collect container logs and save them as artifact. This requires the BuildKite agent to have read permissions on `pods/log` and it will creates a `log/` folder if it doesn't exist (that's new).
* display events related to the build Pods if not all containers were ready when the build finished. This requires the BuildKite agent to have read permissions on `events`. 
* display the raw state of containers that were not ready when the build finished.
* increase the lifetime of the build Pod in order to avoid a race when a build times out, between the tear down commands and the Pod's exit.
* stop patching `activeDeadlineSeconds` on Pods when exiting. I looked into two Pods that were stuck in Terminating state and Kubelet's last message was a failure to stop a container that had already died. I have the suspicion there might be a race in Kubelet between the Pod's shutdown because of its lifetime, and its deletion through kubectl. This is an experimentation. For the last 3/3 builds with this branch, no Pod was stuck but that can certainly be explained by luck. @korbin mentioned this was introduced because of GC issues and I'll keep an eye on it.

/cc @korbin 

